### PR TITLE
Provide GDPR extension integration

### DIFF
--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -345,6 +345,80 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
       TRUE
     );
 
+    $gdprx_installed = CRM_Newsletter_Utils::gdprx_installed();
+    $this->assign('gdprx_installed', $gdprx_installed);
+    if ($gdprx_installed) {
+      $this->add(
+        'checkbox',
+        'gdprx_new_contact',
+        E::ts('Create GDPR record for new contacts')
+      );
+      $this->add(
+        'select',
+        'gdprx_new_contact_category',
+        E::ts('Category'),
+        CRM_Gdprx_Consent::getCategoryList(),
+        TRUE,
+        ['class' => 'crm-select2 huge']
+      );
+      $this->add(
+        'select',
+        'gdprx_new_contact_source',
+        E::ts('Source'),
+        CRM_Gdprx_Consent::getSourceList(),
+        TRUE,
+        ['class' => 'crm-select2 huge']
+      );
+      $this->add(
+        'select',
+        'gdprx_new_contact_type',
+        E::ts('Type'),
+        CRM_Gdprx_Consent::getTypeList(),
+        FALSE,
+        ['class' => 'crm-select2 huge']
+      );
+        $this->add(
+          'textarea',
+          'gdprx_new_contact_note',
+          E::ts('Note')
+        );
+
+      $this->add(
+        'checkbox',
+        'gdprx_unsubscribe_all',
+        E::ts('Create GDPR record when unsubscribing')
+      );
+      $this->add(
+        'select',
+        'gdprx_unsubscribe_all_category',
+        E::ts('Category'),
+        CRM_Gdprx_Consent::getCategoryList(),
+        TRUE,
+        ['class' => 'crm-select2 huge']
+      );
+      $this->add(
+        'select',
+        'gdprx_unsubscribe_all_source',
+        E::ts('Source'),
+        CRM_Gdprx_Consent::getSourceList(),
+        TRUE,
+        ['class' => 'crm-select2 huge']
+      );
+      $this->add(
+        'select',
+        'gdprx_unsubscribe_all_type',
+        E::ts('Type'),
+        CRM_Gdprx_Consent::getTypeList(),
+        FALSE,
+        ['class' => 'crm-select2 huge']
+      );
+      $this->add(
+        'textarea',
+        'gdprx_unsubscribe_all_note',
+        E::ts('Note')
+      );
+    }
+
     $this->addButtons(array(
       array(
         'type' => 'submit',

--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -191,6 +191,16 @@ class CRM_Newsletter_Profile {
       'preferences_url',
       'request_link_url',
       'submit_label',
+      'gdprx_new_contact',
+      'gdprx_new_contact_category',
+      'gdprx_new_contact_source',
+      'gdprx_new_contact_type',
+      'gdprx_new_contact_note',
+      'gdprx_unsubscribe_all',
+      'gdprx_unsubscribe_all_category',
+      'gdprx_unsubscribe_all_source',
+      'gdprx_unsubscribe_all_type',
+      'gdprx_unsubscribe_all_note',
     );
   }
 

--- a/CRM/Newsletter/Utils.php
+++ b/CRM/Newsletter/Utils.php
@@ -36,9 +36,9 @@ class CRM_Newsletter_Utils {
    *   When no contact could be found or created.
    */
   public static function getContact($contact_data) {
-    $result = civicrm_api3('Contact', 'getorcreate', $contact_data);
+    $result = civicrm_api3('Contact', 'createifnotexists', $contact_data);
     if ($result['count'] == 1) {
-      return reset($result['values'])['contact_id'];
+      return reset($result['values']);
     }
     else {
       throw new Exception(E::ts('Could not get or create a contact for the given contact data.'));
@@ -312,6 +312,11 @@ class CRM_Newsletter_Utils {
       ));
     }
     return $group_contact_results;
+  }
+
+  public static function gdprx_installed() {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    return ($manager->getStatus('de.systopia.gdprx') === CRM_Extension_Manager::STATUS_INSTALLED);
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Instead of creating external forms and custom API actions for each project, this
 extension offers configurable newsletter form profiles, along with API actions
 to use as an endpoint for external forms.
 
-This extension is supposed to work with the civicrm_newsletter Drupal module
-for external newsletter management on a Drupal website, but may be used without
-it.
+Note that the extension requires the
+[Extended Contact Manager (XCM)](https://github.com/systopia/de.systopia.xcm)
+extension in version `1.9` or later!
+
+The extension supports for the
+[GDPR Compliance](https://github.com/systopia/de.systopia.gdprx) extension, i.e.
+providing the option of adding GDPR consent records for newly created contacts
+during newsletter subscription, and for the unsubscribe from all mailing lists
+event, both with all consent record attributes (such as category, source, etc.)
+being configurable.
+
+This extension is supposed to work with the
+[civicrm_newsletter](https://github.com/systopia/civicrm_newsletter) Drupal
+module for external newsletter management on a Drupal website, but may be used
+without it, i.e. anything that implements the extension's API.

--- a/api/v3/NewsletterSubscription/Confirm.php
+++ b/api/v3/NewsletterSubscription/Confirm.php
@@ -59,6 +59,24 @@ function civicrm_api3_newsletter_subscription_confirm($params) {
 
       $unsubscribe_from_all_profiles = $profile->getAttribute('mailing_lists_unsubscribe_all_profiles');
       $email_template = 'unsubscribe_all';
+
+      if (
+        CRM_Newsletter_Utils::gdprx_installed()
+        && $profile->getAttribute('gdprx_unsubscribe_all')
+      ) {
+        civicrm_api3(
+          'ConsentRecord',
+          'create',
+          [
+            'contact_id' => $contact_id,
+            'category' => $profile->getAttribute('gdprx_unsubscribe_all_category'),
+            'source' => $profile->getAttribute('gdprx_unsubscribe_all_source'),
+            'type' => $profile->getAttribute('gdprx_unsubscribe_all_type'),
+            'note' => $profile->getAttribute('gdprx_unsubscribe_all_note'),
+            'terms' => $profile->getAttribute('conditions_preferences'),
+          ]
+        );
+      }
     }
     elseif ($params['autoconfirm']) {
       // Mark all pending subscriptions for being added.

--- a/api/v3/NewsletterSubscription/Request.php
+++ b/api/v3/NewsletterSubscription/Request.php
@@ -66,7 +66,8 @@ function civicrm_api3_newsletter_subscription_request($params) {
 
       // Get or create the contact.
       $contact_data = array_intersect_key($params, $profile->getAttribute('contact_fields'));
-      $contact_id = CRM_Newsletter_Utils::getContact($contact_data);
+      $contact_result = CRM_Newsletter_Utils::getContact($contact_data);
+      $contact_id = $contact_result['contact_id'];
     }
 
     $contact = civicrm_api3('Contact', 'getsingle', array(

--- a/info.xml
+++ b/info.xml
@@ -22,10 +22,13 @@
   <compatibility>
     <ver>4.7</ver>
   </compatibility>
+  <requires>
+    <ext>de.systopia.xcm</ext>
+  </requires>
   <comments>
     This extension is supposed to work with the civicrm_newsletter Drupal module
     for external newsletter management on a Drupal website, but may be used
-    without it.
+    without it. It depends on the de.systopia.xcm extension version 1.9+.
   </comments>
   <civix>
     <namespace>CRM/Newsletter</namespace>

--- a/templates/CRM/Newsletter/Form/Profile.tpl
+++ b/templates/CRM/Newsletter/Form/Profile.tpl
@@ -278,6 +278,86 @@
       </table>
       
     </fieldset>
+    {if $gdprx_installed}
+      <fieldset>
+
+        <legend>
+            {ts}GDPR Records{/ts}
+          <div class="description">{ts}Create GDPR records using the de.systopia.gdprx extension.{/ts}</div>
+        </legend>
+
+        <table>
+
+          <tr class="crm-section {cycle values="odd,even"}">
+            <td>
+              <table class="form-layout-compressed">
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_new_contact.label}</td>
+                  <td class="content">{$form.gdprx_new_contact.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_new_contact_category.label}</td>
+                  <td class="content">{$form.gdprx_new_contact_category.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_new_contact_source.label}</td>
+                  <td class="content">{$form.gdprx_new_contact_source.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_new_contact_type.label}</td>
+                  <td class="content">{$form.gdprx_new_contact_type.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_new_contact_note.label}</td>
+                  <td class="content">{$form.gdprx_new_contact_note.html}</td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <tr class="crm-section {cycle values="odd,even"}">
+            <td>
+              <table class="form-layout-compressed">
+                
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_unsubscribe_all.label}</td>
+                  <td class="content">{$form.gdprx_unsubscribe_all.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_unsubscribe_all_category.label}</td>
+                  <td class="content">{$form.gdprx_unsubscribe_all_category.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_unsubscribe_all_source.label}</td>
+                  <td class="content">{$form.gdprx_unsubscribe_all_source.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_unsubscribe_all_type.label}</td>
+                  <td class="content">{$form.gdprx_unsubscribe_all_type.html}</td>
+                </tr>
+
+                <tr class="crm-section">
+                  <td class="label">{$form.gdprx_unsubscribe_all_note.label}</td>
+                  <td class="content">{$form.gdprx_unsubscribe_all_note.html}</td>
+                </tr>
+                
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </fieldset>
+    {/if}
 
   {elseif $op == 'delete'}
     {if $profile_name}


### PR DESCRIPTION
This PR adds support for the [GDPR Compliance](https://github.com/systopia/de.systopia.gdprx) extension, i.e. providing the option of adding GDPR consent records for

- newly created contacts during newsletter subscription
- the unsubscribe from all mailing lists event

both with all consent record attributes (such as category, source, etc.) being configurable.

This PR adds a dependency to the [Extended Contact Matcher (XCM)](https://github.com/systopia/de.systopia.xcm) extension, requiring version `1.9`, specifically the `Contact.createifnotexists` API action, which returns whether the contact has been created or matched, since this is crucial information for one of the GDPR consent records.