### PR TITLE
Always use current group title (prefer frontend title if not empty)

### DIFF
--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -460,10 +460,10 @@ class CRM_Newsletter_Profile {
           'is_active' => 1,
           'group_type' => array('LIKE' => '%' . CRM_Utils_Array::implodePadded($group_type['value']) . '%'),
           'option.limit'   => 0,
-          'return'         => 'id,title'
+          'return'         => 'id,title,frontend_title'
         ));
         foreach ($query['values'] as $group) {
-          $groups[$group['id']] = $group['title'];
+          $groups[$group['id']] = $group['frontend_title'] ?: $group['title'];
         }
       }
     }

--- a/CRM/Newsletter/Utils.php
+++ b/CRM/Newsletter/Utils.php
@@ -89,10 +89,11 @@ class CRM_Newsletter_Utils {
     $mailing_lists = array();
     foreach (reset($subscription['values'])['subscription_status'] as $group_id => $group_status) {
       $group = civicrm_api3('Group', 'getsingle', array(
-        'id' => $group_id
+        'id' => $group_id,
+        'return' => ['id', 'title', 'frontend_title']
       ));
       $mailing_lists[$group_id] = array(
-        'title' => $group['title'],
+        'title' => $group['frontend_title'] ?: $group['title'],
         'status' => E::ts($group_status),
         'status_raw' => $group_status,
       );
@@ -118,12 +119,12 @@ class CRM_Newsletter_Utils {
       // Retrieve group information.
       $group = civicrm_api3('Group', 'getsingle', array(
         'id' => $group_id,
-        'return' => array('children', 'description', 'name', 'parents'),
+        'return' => array('children', 'description', 'name', 'title', 'frontend_title', 'parents'),
       ));
 
       // Compose the group item.
       $group_tree_item = array(
-        'title' => $group_title,
+        'title' => $group['frontend_title'] ?: $group['title'],
         'description' => !empty($group['description']) ? $group['description'] : '',
         'name' => !empty($group['name']) ? $group['name'] : '',
       );

--- a/CRM/Newsletter/Utils.php
+++ b/CRM/Newsletter/Utils.php
@@ -119,13 +119,13 @@ class CRM_Newsletter_Utils {
       // Retrieve group information.
       $group = civicrm_api3('Group', 'getsingle', array(
         'id' => $group_id,
-        'return' => array('children', 'description', 'name', 'title', 'frontend_title', 'parents'),
+        'return' => array('children', 'description', 'frontend_description', 'name', 'title', 'frontend_title', 'parents'),
       ));
 
       // Compose the group item.
       $group_tree_item = array(
         'title' => $group['frontend_title'] ?: $group['title'],
-        'description' => !empty($group['description']) ? $group['description'] : '',
+        'description' => $group['frontend_description'] ?: $group['description'] ?: '',
         'name' => !empty($group['name']) ? $group['name'] : '',
       );
       // Add children.


### PR DESCRIPTION
Resolves #3.

Instead of submitting stored group titles from when the profile was last stored, always fetch current group titles for sending e-mail and providing field metadata of a profile via the API. Also, use the public group title (`frontend_title`) if not empty.