### PR TITLE
Allow overriding option labels for contact fields

### DIFF
--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -170,7 +170,11 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
       $contact_field_names[$contact_field_name]['description'] = 'contact_field_' . $contact_field_name . '_description';
 
       // Add fields for overriding option value labels.
-      if (!empty($contact_field['options'])) {
+      if (!empty($contact_field['options']) && !in_array($contact_field_name, [
+          'country_id',
+          'state_province_id',
+          'county_id',
+        ])) {
         foreach ($contact_field['options'] as $option_value => $option_label) {
           $this->add(
             'text',

--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -134,6 +134,14 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
       FALSE
     );
 
+    $this->add(
+      'select',
+      'language',
+      E::ts('Language'),
+      ['' => E::ts('- Default language -')] + CRM_Core_I18n::uiLanguages(),
+      FALSE
+    );
+
     $contact_fields = CRM_Newsletter_Profile::availableContactFields();
     $contact_field_names = array();
     foreach ($contact_fields as $contact_field_name => $contact_field) {

--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -168,6 +168,18 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
         E::ts('Field description')
       );
       $contact_field_names[$contact_field_name]['description'] = 'contact_field_' . $contact_field_name . '_description';
+
+      // Add fields for overriding option value labels.
+      if (!empty($contact_field['options'])) {
+        foreach ($contact_field['options'] as $option_value => $option_label) {
+          $this->add(
+            'text',
+            'contact_field_' . $contact_field_name . '_option_' . $option_value,
+            E::ts('Label for option %1', [1 => $option_label])
+          );
+          $contact_field_names[$contact_field_name]['options'][$option_value] = 'contact_field_' . $contact_field_name . '_option_' . $option_value;
+        }
+      }
     }
     $this->assign('contact_field_names', $contact_field_names);
 
@@ -558,6 +570,11 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
             }
             $defaults['contact_field_' . $contact_field . '_label'] = $values['label'];
             $defaults['contact_field_' . $contact_field . '_description'] = $values['description'];
+            if (!empty($values['options'])) {
+              foreach ($values['options'] as $option_value => $option_label) {
+                $defaults['contact_field_' . $contact_field . '_option_' . $option_value] = $option_label;
+              }
+            }
           }
         }
         elseif ($element_name == 'mailing_lists') {
@@ -597,6 +614,13 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
               }
               $values['contact_fields'][$contact_field_name]['label'] = $values['contact_field_' . $contact_field_name . '_label'];
               $values['contact_fields'][$contact_field_name]['description'] = $values['contact_field_' . $contact_field_name . '_description'];
+              if (!empty($contact_field['options'])) {
+                foreach ($contact_field['options'] as $option_value => $option_label) {
+                  if ($values['contact_field_' . $contact_field_name . '_option_' . $option_value] !== '') {
+                    $values['contact_fields'][$contact_field_name]['options'][$option_value] = $values['contact_field_' . $contact_field_name . '_option_' . $option_value];
+                  }
+                }
+              }
             }
           }
         }

--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -165,6 +165,7 @@ class CRM_Newsletter_Profile {
     return array(
       'xcm_profile',
       'form_title',
+      'language',
       'contact_fields',
       'mailing_lists',
       'mailing_lists_label',
@@ -348,6 +349,7 @@ class CRM_Newsletter_Profile {
     $default_data = array(
       'xcm_profile' => '',
       'form_title' => '',
+      'language' => Civi::settings()->get('lcMessages'),
       'contact_fields' => array(),
       'mailing_lists' => self::getGroups(),
       'mailing_lists_label' => E::ts('Mailing lists'),

--- a/api/v3/NewsletterProfile/Getsingle.php
+++ b/api/v3/NewsletterProfile/Getsingle.php
@@ -39,7 +39,10 @@ function civicrm_api3_newsletter_profile_getsingle($params) {
     foreach ($profile_data['contact_fields'] as $field_name => &$field) {
       $field['type'] = $contact_fields[$field_name]['type'];
       if (!empty($contact_fields[$field_name]['options'])) {
-        $field['options'] = $contact_fields[$field_name]['options'];
+        $field['options'] = array_replace(
+          $contact_fields[$field_name]['options'],
+            $field['options'] ?? []
+        );
       }
     }
 

--- a/api/v3/NewsletterProfile/Getsingle.php
+++ b/api/v3/NewsletterProfile/Getsingle.php
@@ -38,10 +38,12 @@ function civicrm_api3_newsletter_profile_getsingle($params) {
     $contact_fields = CRM_Newsletter_Profile::availableContactFields();
     foreach ($profile_data['contact_fields'] as $field_name => &$field) {
       $field['type'] = $contact_fields[$field_name]['type'];
+
+      // Replace options defined in profile configuration.
       if (!empty($contact_fields[$field_name]['options'])) {
         $field['options'] = array_replace(
           $contact_fields[$field_name]['options'],
-            $field['options'] ?? []
+            array_filter($field['options'], function ($replacement) { return isset($replacement) && $replacement !== ''; }) ?? []
         );
       }
     }

--- a/api/v3/NewsletterProfile/Getsingle.php
+++ b/api/v3/NewsletterProfile/Getsingle.php
@@ -34,6 +34,12 @@ function civicrm_api3_newsletter_profile_getsingle($params) {
     $profile_name = $profile->getName();
     $profile_data = $profile->getData();
 
+    // Set locale to profile language for translated option values.
+    $current_locale = CRM_Core_I18n::getLocale();
+    $profile_locale = $profile_data['language'] ?: Civi::settings()->get('lcMessages');
+    CRM_Core_Session::singleton()->set('lcMessages', $profile_locale);
+    CRM_Core_I18n::singleton()->setLocale($profile_locale);
+
     // Add contact field type and options, if applicable.
     $contact_fields = CRM_Newsletter_Profile::availableContactFields();
     foreach ($profile_data['contact_fields'] as $field_name => &$field) {
@@ -60,9 +66,18 @@ function civicrm_api3_newsletter_profile_getsingle($params) {
     $profile_data['mailing_lists_tree'] = $group_tree;
 
     $return = array($profile_name => $profile_data);
+
+    // Reset locale to original language.
+    CRM_Core_Session::singleton()->set('lcMessages', $current_locale);
+    CRM_Core_I18n::singleton()->setLocale($current_locale);
+
     return civicrm_api3_create_success($return);
   }
   catch (\Exception $exception) {
+    // Reset locale to original language.
+    CRM_Core_Session::singleton()->set('lcMessages', $current_locale);
+    CRM_Core_I18n::singleton()->setLocale($current_locale);
+
     return civicrm_api3_create_error($exception->getMessage(), array('error_code' => $exception->getCode()));
   }
 }

--- a/templates/CRM/Newsletter/Form/Profile.tpl
+++ b/templates/CRM/Newsletter/Form/Profile.tpl
@@ -44,6 +44,11 @@
           </tr>
 
           <tr class="crm-section">
+            <td class="label">{$form.language.label}</td>
+            <td class="content">{$form.language.html}</td>
+          </tr>
+
+          <tr class="crm-section">
             <td class="label">{$form.optin_url.label}</td>
             <td class="content">
                 {$form.optin_url.html}

--- a/templates/CRM/Newsletter/Form/Profile.tpl
+++ b/templates/CRM/Newsletter/Form/Profile.tpl
@@ -158,6 +158,23 @@
                       <td class="label">{$form.$field_name_description.label}</td>
                       <td class="content">{$form.$field_name_description.html}</td>
                     </tr>
+
+                    {if !empty($contact_field.options)}
+                      <tr class="crm-section">
+                        <td class="label">{ts}Replace option labels{/ts}</td>
+                        <td>
+                          <table class="form-layout-compressed">
+                              {foreach from=$contact_field.options item=field_name_option}
+                                <tr class="crm-section">
+                                  <td class="label">{$form.$field_name_option.label}</td>
+                                  <td class="content">{$form.$field_name_option.html}</td>
+                                </tr>
+                              {/foreach}
+                          </table>
+                        </td>
+                      </tr>
+                    {/if}
+
                   </table>
                 </td>
 


### PR DESCRIPTION
* Allow using localoized versions (e.g. for countries) by adding a language selector to the profile
* Allow overriding option value labels that are not being localized (e.g. individual prefix options)