### PR TITLE
Use a timely restricted contact checksum instead of the contact hash

### DIFF
--- a/CRM/Newsletter/Upgrader.php
+++ b/CRM/Newsletter/Upgrader.php
@@ -43,4 +43,25 @@ class CRM_Newsletter_Upgrader extends CRM_Newsletter_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Replace "[CONTACT_HASH]" with "[CONTACT_CHECKSUM"] in URLs.
+   */
+  public function upgrade_5101(): bool {
+    foreach (CRM_Newsletter_Profile::getProfiles() as $profile) {
+      foreach(['optin_url', 'preferences_url', 'request_link_url'] as $attribute_name) {
+        $profile->setAttribute(
+          $attribute_name,
+          str_replace(
+            '[CONTACT_HASH]',
+            '[CONTACT_CHECKSUM]',
+            $profile->getAttribute($attribute_name) ?? ''
+          )
+        );
+        $profile->saveProfile();
+      }
+    }
+
+    return TRUE;
+  }
+
 }

--- a/CRM/Newsletter/Utils.php
+++ b/CRM/Newsletter/Utils.php
@@ -202,7 +202,7 @@ class CRM_Newsletter_Utils {
    *
    * @throws \Exception
    */
-  public static function send_configured_mail($contact, $profile, $type) {
+  public static function send_configured_mail($contact, string $contact_checksum, $profile, $type) {
     // Prepare token (Smarty variables) values.
     switch ($type) {
       case 'unsubscribe_all':
@@ -229,8 +229,8 @@ class CRM_Newsletter_Utils {
     // Construct opt-in URL.
     $optin_url = $profile->getAttribute('optin_url');
     $optin_url = str_replace(
-      '[CONTACT_HASH]',
-      $contact['hash'],
+      '[CONTACT_CHECKSUM]',
+      $contact_checksum,
       $optin_url
     );
     $optin_url = str_replace(
@@ -242,8 +242,8 @@ class CRM_Newsletter_Utils {
     // Construct preferences URL.
     $preferences_url = $profile->getAttribute('preferences_url');
     $preferences_url = str_replace(
-      '[CONTACT_HASH]',
-      $contact['hash'],
+      '[CONTACT_CHECKSUM]',
+      $contact_checksum,
       $preferences_url
     );
     $preferences_url = str_replace(

--- a/Civi/Newsletter/ContactChecksumService.php
+++ b/Civi/Newsletter/ContactChecksumService.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Newsletter;
+
+class ContactChecksumService {
+
+  private static self $instance;
+
+  public static function getInstance(): self {
+    return self::$instance ??= new self();
+  }
+
+  /**
+   * Generates a timely limited contact checksum that can be resolved back to
+   * the contact ID. The checksum expires after the number of days configured in
+   * the Civi setting "checksum_timeout".
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @see resolveChecksum()
+   */
+  public function generateChecksum(int $contact_id): string {
+    return $contact_id . '_' . \CRM_Contact_BAO_Contact_Utils::generateChecksum($contact_id);
+  }
+
+  /**
+   * Verifies a contact checksum and resolves it to the contact ID.
+   *
+   * @return int
+   *   The resolved contact ID or NULL if the checksum isn't valid.
+   *
+   * @throws \CRM_Core_Exception
+   *
+   * @see generateChecksum()
+   */
+  public function resolveChecksum(string $contact_checksum): ?int {
+    if (preg_match('/^(?<contact_id>[1-9][0-9]*)_(?<checksum>[0-9a-z_]+)$/i', $contact_checksum, $match)) {
+      $contact_id = (int) $match['contact_id'];
+      if (\CRM_Contact_BAO_Contact_Utils::validChecksum($contact_id, $match['checksum'])) {
+        return $contact_id;
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/api/v3/NewsletterSubscription/Submit.php
+++ b/api/v3/NewsletterSubscription/Submit.php
@@ -13,6 +13,7 @@
 | written permission from the original author(s).             |
 +-------------------------------------------------------------*/
 
+use Civi\Newsletter\ContactChecksumService;
 use CRM_Newsletter_ExtensionUtil as E;
 
 /**
@@ -62,11 +63,7 @@ function civicrm_api3_newsletter_subscription_submit($params) {
     $contact = civicrm_api3('Contact', 'getsingle', array(
       'id' => $contact_id,
     ));
-    $contact_hash = civicrm_api3('Contact', 'getsingle', array(
-      'id' => $contact_id,
-      'return' => array('hash')
-    ));
-    $contact['hash'] = $contact_hash['hash'];
+    $contact_checksum = ContactChecksumService::getInstance()->generateChecksum($contact_id);
 
     // Validate submitted group IDs.
     if (!is_array($params['mailing_lists'])) {
@@ -122,6 +119,7 @@ function civicrm_api3_newsletter_subscription_submit($params) {
     // Send an e-mail with the opt-in template.
     CRM_Newsletter_Utils::send_configured_mail(
       $contact,
+      $contact_checksum,
       $profile,
       'optin'
     );

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,8 +5,8 @@ within the *System settings* section (civicrm/admin/settings/newsletter). This
 page offers you to *Configure profiles*.
 
 !!!tip
-    Also make sure that you install and configure the CiviCRM Extension 
-    "Extended Contact Matcher" (de.systopia.xcm) to define yor contact matching 
+    Also make sure that you install and configure the CiviCRM Extension
+    "Extended Contact Matcher" (de.systopia.xcm) to define yor contact matching
     behaviour. Please refer to the extension's
     [documentation](https://docs.civicrm.org/xcm/en/latest/).
 
@@ -15,7 +15,7 @@ page offers you to *Configure profiles*.
 Profiles define properties of newsletter subscription and accompanying
 preferences forms for users to manage their subscriptions. There will always be
 a *default* profile - at the very least you should configure this default
-profile or create a new one. 
+profile or create a new one.
 
 ![Profile Configuration](img/profile_configuration.png?raw=true "Profile Configuration")
 
@@ -29,12 +29,12 @@ in order to navigate your recipients to the correct personal preference page.
 - *Submit button label*: The form's submit button will have this as a caption.
 - *Preferences URL*: This must be set to the URL of the form for users to manage
   their subscription preferences and must include placeholders for the profile
-  name `[PROFILE]` and a hash string identifying the CiviCRM contact
-  `[CONTACT_HASH]`. The URL will be used for links in e-mails generated and sent
-  by the extension to inform users about their subscription and how to manage
-  them.
+  name `[PROFILE]` and a checksum string identifying the CiviCRM contact
+  `[CONTACT_CHECKSUM]`. The URL will be used for links in e-mails generated and
+  sent by the extension to inform users about their subscription and how to
+  manage them.
 - *Unsubscribe to all Mailingslists button*: If you choose to provide that
-  button, contacts can unsubcribe from all mailing lists in your system.
+  button, contacts can unsubscribe from all mailing lists in your system.
 
 ### Mailing lists
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ unsubscribing, you should not use CiviCRM default tokens when sending a mailing
 but the custom token provided by the extension that links users to their
 personal preferences page. The token for the default profile is
 `{newsletter.preferences_url_default}` but you will be able to choose the token
-for the profile you would like to link to from CiviCRM's token menu.  
+for the profile you would like to link to from CiviCRM's token menu.
 
 ![Token Menu](img/token_menu.png?raw=true "Token Menu")
 
@@ -28,7 +28,7 @@ confirming their subscription and possibly changing them at a later stage.
 - In order to change their preferences, the user needs to use a personalized
   link. That link can be included in CiviCRM mailings via the tokens provided by
   the extension or by your external system. The link needs to contain the
-  contact's hash and the identifier for the profile being used.
+  contact's checksum and the identifier for the profile being used.
 
 ### Subscription stage
 
@@ -56,7 +56,7 @@ stage.
 
 When generating this form, the system issues a request to the API action
 `NewsletterSubscription.Get` that this extension provides. Taking the profile
-name and the contact hash, this action retrieves the subscription status for
+name and the contact checksum, this action retrieves the subscription status for
 all mailing lists and the contact data for all contact fields defined within the
 given profile, and sends it to the system which, in turn, creates the
 preferences form based on that information.
@@ -94,8 +94,8 @@ When generating this form, the system issues a request to the API action
 within the profile, but no mailing list options. Instead of presenting a form
 for the user to input their contact data again, a link may be provided to
 request the API to re-send the confirmation e-mail (containing a link to the
-preferences page) by providing the contact hash and the contact ID (which is to
-be retrieved using the contact hash).
+preferences page) by providing the contact checksum and the contact ID (which is
+to be retrieved using the contact checksum).
 
 The form input is sent in to the `NewsletterSubscription.Request` API action,
 which will generate and send the information e-mail to the contact as in the

--- a/info.xml
+++ b/info.xml
@@ -38,6 +38,7 @@
     <mixin>menu-xml@1.0.0</mixin>
   </mixins>
   <classloader>
+    <psr4 prefix="Civi\" path="Civi"/>
     <psr0 prefix="CRM_" path="."/>
   </classloader>
 </extension>

--- a/newsletter.php
+++ b/newsletter.php
@@ -1,6 +1,8 @@
 <?php
 
 require_once 'newsletter.civix.php';
+
+use Civi\Newsletter\ContactChecksumService;
 use CRM_Newsletter_ExtensionUtil as E;
 
 /**
@@ -174,12 +176,12 @@ function newsletter_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = 
   if (is_array($cids) && array_key_exists('newsletter', $tokens)) {
     foreach (CRM_Newsletter_Profile::getProfiles() as $profile_name => $profile) {
       foreach ($cids as $cid) {
-        $contact = civicrm_api3('Contact', 'getsingle', array('id' => $cid, 'return' => array('hash')));
+        $contact_checksum = ContactChecksumService::getInstance()->generateChecksum($cid);
 
         $optin_url = $profile->getAttribute('optin_url');
         $optin_url = str_replace(
-          '[CONTACT_HASH]',
-          $contact['hash'],
+          '[CONTACT_CHECKSUM]',
+          $contact_checksum,
           $optin_url
         );
         $optin_url = str_replace(
@@ -191,8 +193,8 @@ function newsletter_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = 
 
         $preferences_url = $profile->getAttribute('preferences_url');
         $preferences_url = str_replace(
-          '[CONTACT_HASH]',
-          $contact['hash'],
+          '[CONTACT_CHECKSUM]',
+          $contact_checksum,
           $preferences_url
         );
         $preferences_url = str_replace(
@@ -204,8 +206,8 @@ function newsletter_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = 
 
         $request_link_url = $profile->getAttribute('request_link_url');
         $request_link_url = str_replace(
-          '[CONTACT_HASH]',
-          $contact['hash'],
+          '[CONTACT_CHECKSUM]',
+          $contact_checksum,
           $request_link_url
         );
         $request_link_url = str_replace(

--- a/templates/CRM/Newsletter/Form/Profile.tpl
+++ b/templates/CRM/Newsletter/Form/Profile.tpl
@@ -53,7 +53,7 @@
             <td class="content">
                 {$form.optin_url.html}
               <div class="description">
-                  {ts}A URL to the opt-in page. Must include the tokens <code>[PROFILE]</code> and <code>[CONTACT_HASH]</code> which will be replaced with the actual contact hash for identifying the contact.{/ts}
+                  {ts}A URL to the opt-in page. Must include the tokens <code>[PROFILE]</code> and <code>[CONTACT_CHECKSUM]</code> which will be replaced with the actual contact checksum for identifying the contact.{/ts}
               </div>
             </td>
           </tr>
@@ -63,7 +63,7 @@
             <td class="content">
                 {$form.preferences_url.html}
               <div class="description">
-                  {ts}A URL to the preferences form. Must include the tokens <code>[PROFILE]</code> and <code>[CONTACT_HASH]</code> which will be replaced with the actual contact hash for identifying the contact.{/ts}
+                  {ts}A URL to the preferences form. Must include the tokens <code>[PROFILE]</code> and <code>[CONTACT_CHECKSUM]</code> which will be replaced with the actual contact checksum for identifying the contact.{/ts}
               </div>
             </td>
           </tr>
@@ -73,7 +73,7 @@
             <td class="content">
                 {$form.request_link_url.html}
               <div class="description">
-                  {ts}A URL to the Request link form. Must include the token <code>[PROFILE]</code> and may include the token <code>[CONTACT_HASH]</code> which will be replaced with the actual contact hash for identifying the contact.{/ts}
+                  {ts}A URL to the Request link form. Must include the token <code>[PROFILE]</code> and may include the token <code>[CONTACT_CHECKSUM]</code> which will be replaced with the actual contact checksum for identifying the contact.{/ts}
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Use a timely restricted contact hash instead of CiviCRM's hash of the contact entity. Fixes #11.