### PR TITLE
Include "Radio" fields and improve options definition

### DIFF
--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -326,14 +326,17 @@ class CRM_Newsletter_Profile {
         if (in_array($contact_field['html_type'], array(
           'Multi-Select',
           'CheckBox',
+          'Radio',
           'Select'
         ))) {
-          $option_values = civicrm_api3('OptionValue', 'get', array(
-            'option_group_id' => $contact_field['option_group_id'],
-          ));
-          $dynamic['custom_' . $contact_field['id']]['options'] = array();
-          foreach ($option_values['values'] as $option_value) {
-            $dynamic['custom_' . $contact_field['id']]['options'][$option_value['value']] = $option_value['label'];
+          if (!empty($contact_field['option_group_id'])) {
+            $option_values = civicrm_api3('OptionValue', 'get', array(
+              'option_group_id' => $contact_field['option_group_id'],
+            ));
+            $dynamic['custom_' . $contact_field['id']]['options'] = array();
+            foreach ($option_values['values'] as $option_value) {
+              $dynamic['custom_' . $contact_field['id']]['options'][$option_value['value']] = $option_value['label'];
+            }
           }
         }
       }


### PR DESCRIPTION
Somehow the original implementation forgot about `Radio` type fields. Also, allowed options were not added correctly (possibly leading to empty option lists for fields that don't have any options, e.g. `Radio` type fields (*Yes/No* fields), although they're somewhat poorly designed in that they're basically a single radio button with no option to revert a choice. So those will have to be handled differently by API implementations.