### PR TITLE
Make sender address configurable per profile

### DIFF
--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -298,6 +298,15 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
     );
 
     $this->add(
+      'select',
+      'sender_email',
+      E::ts('Sender'),
+      $this->getSenderOptions(),
+      true,
+      ['class' => 'crm-select2 huge']
+    );
+
+    $this->add(
       'text',
       'template_optin_subject',
       E::ts('Subject for opt-in e-mail'),
@@ -675,6 +684,18 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
       }
     }
     return static::$_xcm_profiles;
+  }
+
+  /**
+   * Get a list of the available/allowed sender email addresses
+   */
+  protected function getSenderOptions() {
+    $dropdown_list = [];
+    $from_email_addresses = CRM_Core_OptionGroup::values('from_email_address');
+    foreach ($from_email_addresses as $key => $from_email_address) {
+      $dropdown_list[$key] = htmlentities($from_email_address);
+    }
+    return $dropdown_list;
   }
 
 }

--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -14,6 +14,7 @@
 +-------------------------------------------------------------*/
 
 use CRM_Newsletter_ExtensionUtil as E;
+use Civi\Api4\OptionValue;
 
 /**
  * Form controller class
@@ -690,16 +691,17 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
    * Get a list of the available/allowed sender email addresses
    */
   protected function getSenderOptions() {
-    $dropdown_list = [];
-    $from_email_addresses = CRM_Core_OptionGroup::values('from_email_address');
-    $default_from = CRM_Core_OptionGroup::getDefaultValue('from_email_address');
-    // set default from address at the beginning of the array, so that it will be the prefilled value
-    array_unshift($from_email_addresses, $from_email_addresses[$default_from]);
-    unset($from_email_addresses[$default_from]);
-    foreach ($from_email_addresses as $key => $from_email_address) {
-      $dropdown_list[$key] = htmlentities($from_email_address);
-    }
-    return $dropdown_list;
+    $from_email_addresses = OptionValue::get(FALSE)
+      ->addSelect('label', 'value', 'is_default')
+      ->addWhere('option_group_id:name', '=', 'from_email_address')
+      ->addOrderBy('is_default', 'DESC')
+      ->execute()
+      ->indexBy('value')
+      ->column('label');
+    return array_map(function($value) {
+      return htmlspecialchars($value);
+    }, $from_email_addresses);
+    return $from_email_addresses;
   }
 
 }

--- a/CRM/Newsletter/Form/Profile.php
+++ b/CRM/Newsletter/Form/Profile.php
@@ -692,6 +692,10 @@ class CRM_Newsletter_Form_Profile extends CRM_Core_Form {
   protected function getSenderOptions() {
     $dropdown_list = [];
     $from_email_addresses = CRM_Core_OptionGroup::values('from_email_address');
+    $default_from = CRM_Core_OptionGroup::getDefaultValue('from_email_address');
+    // set default from address at the beginning of the array, so that it will be the prefilled value
+    array_unshift($from_email_addresses, $from_email_addresses[$default_from]);
+    unset($from_email_addresses[$default_from]);
     foreach ($from_email_addresses as $key => $from_email_address) {
       $dropdown_list[$key] = htmlentities($from_email_address);
     }

--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -366,7 +366,7 @@ class CRM_Newsletter_Profile {
       'conditions_preferences' => '',
       'conditions_preferences_label' => '',
       'conditions_preferences_description' => '',
-      'sender_email' => CRM_Core_OptionGroup::getDefaultValue('from_email_address'),
+      'sender_email' => CRM_Newsletter_Utils::getFromEmailAddress(),
       'template_optin_subject' => E::ts('Your newsletter subscription'),
       'template_optin' => '', // TODO: A default opt-in e-mail template with a token for the link to the preferences page.
       'template_info_subject' => E::ts('Your newsletter subscription preferences'),

--- a/CRM/Newsletter/Profile.php
+++ b/CRM/Newsletter/Profile.php
@@ -181,6 +181,7 @@ class CRM_Newsletter_Profile {
       'conditions_preferences',
       'conditions_preferences_label',
       'conditions_preferences_description',
+      'sender_email',
       'template_optin_subject',
       'template_optin',
       'template_optin_html',
@@ -365,6 +366,7 @@ class CRM_Newsletter_Profile {
       'conditions_preferences' => '',
       'conditions_preferences_label' => '',
       'conditions_preferences_description' => '',
+      'sender_email' => CRM_Core_OptionGroup::getDefaultValue('from_email_address'),
       'template_optin_subject' => E::ts('Your newsletter subscription'),
       'template_optin' => '', // TODO: A default opt-in e-mail template with a token for the link to the preferences page.
       'template_info_subject' => E::ts('Your newsletter subscription preferences'),

--- a/CRM/Newsletter/Utils.php
+++ b/CRM/Newsletter/Utils.php
@@ -48,20 +48,20 @@ class CRM_Newsletter_Utils {
   /**
    * Returns "From" e-mail addresses configured within CiviCRM.
    *
-   * @param bool $default
-   *   Whether to return only default addresses.
+   * @param CRM_Newsletter_Profile $profile
+   *   The newsletter profile
    *
    * @return string
-   *   The first "From" e-mail address found.
+   *   The "From" e-mail address defined in $profile. If it doesn't exist, the default "From" e-mail address is returned.
    */
-  public static function getFromEmailAddress($default = FALSE) {
-    if ($default) {
-      $condition = ' AND is_default = 1';
+  public static function getFromEmailAddress(CRM_Newsletter_Profile $profile) {
+    $from_addresses = CRM_Core_OptionGroup::values('from_email_address');
+    if (isset($from_addresses[$profile->getAttribute('sender_email')])) {
+      $sender = $from_addresses[$profile->getAttribute('sender_email')];
+    } else {
+      $sender = $from_addresses[CRM_Core_OptionGroup::getDefaultValue('from_email_address')];
     }
-    else {
-      $condition = NULL;
-    }
-    return reset(CRM_Core_OptionGroup::values('from_email_address', NULL, NULL, NULL, $condition));
+    return $sender;
   }
 
   /**
@@ -254,7 +254,7 @@ class CRM_Newsletter_Utils {
 
     // Construct e-mail parameters.
     $mail_params = array(
-      'from' => CRM_Newsletter_Utils::getFromEmailAddress(TRUE),
+      'from' => CRM_Newsletter_Utils::getFromEmailAddress($profile),
       'toName' => $contact['display_name'],
       'toEmail' => $contact['email'],
       'cc' => '',

--- a/api/v3/NewsletterSubscription/Request.php
+++ b/api/v3/NewsletterSubscription/Request.php
@@ -112,7 +112,7 @@ function civicrm_api3_newsletter_subscription_request($params) {
       $preferences_url
     );
     $mail_params = array(
-      'from' => CRM_Newsletter_Utils::getFromEmailAddress(TRUE),
+      'from' => CRM_Newsletter_Utils::getFromEmailAddress($profile),
       'toName' => $contact['display_name'],
       'toEmail' => $contact['email'],
       'cc' => '',

--- a/templates/CRM/Newsletter/Form/Profile.tpl
+++ b/templates/CRM/Newsletter/Form/Profile.tpl
@@ -248,6 +248,17 @@
           <tr class="crm-section  {cycle values="odd,even"}">
             <td>
               <table class="form-layout-compressed">
+                <tr class="crm-section">
+                  <td class="label">{$form.sender_email.label}</td>
+                  <td class="content">{$form.sender_email.html}</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr class="crm-section  {cycle values="odd,even"}">
+            <td>
+              <table class="form-layout-compressed">
 
                 <tr class="crm-section">
                   <td class="label">{$form.template_optin_subject.label}</td>


### PR DESCRIPTION
Add an option to choose the sender email address for a profile. Before, the default sender address was always used and couldn't be changed.

systopia-reference: 21024