### PR TITLE
Define permission as an associative array for CiviCRM 5.71 compatibility

### DIFF
--- a/newsletter.php
+++ b/newsletter.php
@@ -100,7 +100,12 @@ function newsletter_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_permission
  */
 function newsletter_civicrm_permission(&$permissions) {
-  $permissions['access Advanced Newsletter Management API'] = 'Advanced Newsletter Management: Access API';
+  $permissions['access Advanced Newsletter Management API'] = [
+    'label' => E::ts('Advanced Newsletter Management: Access API'),
+    'description' => E::ts(
+      'Allows accessing the API for retrieving, creating, and confirming newsletter subscriptions via the CiviCRM Advanced Newsletter Management API.'
+    ),
+  ];
 }
 
 /**


### PR DESCRIPTION
Fixes deprecation messages:
```
User deprecated function: Permission 'access Advanced Newsletter Management API' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions in CRM_Core_Error::deprecatedWarning() (line 1129 of /path/to/civicrm/civicrm-core/CRM/Core/Error.php).
```