### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -16,11 +16,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.newsletter/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <requires>
     <ext>de.systopia.xcm</ext>

--- a/templates/CRM/Newsletter/Page/Configuration.tpl
+++ b/templates/CRM/Newsletter/Page/Configuration.tpl
@@ -14,12 +14,12 @@
 <div class="crm-block crm-content-block">
   <div class="crm-submit-buttons">
 
-    <a href="{crmURL p="civicrm/admin/settings/newsletter/profiles"}" title="{ts domain="de.systopia.newsletter"}Profiles{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/settings/newsletter/profiles"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter"}Profiles{/ts}" class="button">
       <span>{ts domain="de.systopia.newsletter"}Configure profiles{/ts}</span>
     </a>
 
     {if $settings}
-      <a href="{crmURL p="civicrm/admin/settings/newsletter/settings"}" title="{ts domain="de.systopia.newsletter"}Settings{/ts}" class="button">
+      <a href="{crmURL p="civicrm/admin/settings/newsletter/settings"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter"}Settings{/ts}" class="button">
         <span>{ts domain="de.systopia.newsletter"}Configure extension settings{/ts}</span>
       </a>
     {/if}

--- a/templates/CRM/Newsletter/Page/Profiles.tpl
+++ b/templates/CRM/Newsletter/Page/Profiles.tpl
@@ -15,7 +15,7 @@
 <div class="crm-block crm-content-block crm-newsletter-content-block">
 
   <div class="crm-submit-buttons">
-    <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=create"}" title="{ts domain="de.systopia.newsletter"}New profile{/ts}" class="button">
+    <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=create"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter"}New profile{/ts}" class="button">
       <span><i class="crm-i fa-plus-circle"></i> {ts domain="de.systopia.newsletter"}New profile{/ts}</span>
     </a>
   </div>
@@ -34,11 +34,11 @@
         <tr>
           <td>{$profile.name}</td>
           <td>
-            <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=edit&pname=$profile_name"}" title="{ts domain="de.systopia.newsletter" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Edit{/ts}</a>
+            <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=edit&pname=$profile_name"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter" 1=$profile.name}Edit profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Edit{/ts}</a>
             {if $profile_name == 'default'}
-              <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=delete&pname=$profile_name"}" title="{ts domain="de.systopia.newsletter" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Reset{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=delete&pname=$profile_name"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter" 1=$profile.name}Reset profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Reset{/ts}</a>
             {else}
-              <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=delete&pname=$profile_name"}" title="{ts domain="de.systopia.newsletter" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Delete{/ts}</a>
+              <a href="{crmURL p="civicrm/admin/settings/newsletter/profile" q="op=delete&pname=$profile_name"}" title="{ts escape='htmlattribute' domain="de.systopia.newsletter" 1=$profile.name}Delete profile %1{/ts}" class="action-item crm-hover-button">{ts domain="de.systopia.newsletter"}Delete{/ts}</a>
             {/if}
 
           </td>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.